### PR TITLE
Improve build instructions by making them more reproducible and generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Website of the SPARQL Anything project: http://sparql-anything.cc
 ## Build
 
 ```
-gem install jekyll
+git clone https://github.com/SPARQL-Anything/sparql.anything/
+cd $_
+echo "gem 'jekyll', '~> 4.4.1'" > Gemfile
 bundle exec jekyll serve --config=_config.yml --livereload
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Website of the SPARQL Anything project: http://sparql-anything.cc
 ## Build
 
 ```
+gem install jekyll
 bundle exec jekyll serve --config=_config.yml --livereload
 ```
 


### PR DESCRIPTION
As someone who had never used Jekyll before [this](https://stackoverflow.com/questions/10012181/bundle-install-returns-could-not-locate-gemfile/39255803#39255803) really helped find the way to fix this.